### PR TITLE
Update attributes to use new mirror address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+* Update the mirror URL to use gna.org instead of sourceforge
+
 ## 0.4.0
 
 * Enhancement: [#2]: Changes to use chef package resource to install wkhtmltopdf

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,6 +3,7 @@ default['wkhtmltopdf']['version']     = '0.12.0'
 default['wkhtmltopdf']['install_dir'] = '/usr/local/bin'
 default['wkhtmltopdf']['lib_dir']     = ''
 
+default['wkhtmltopdf-update']['major_version'] = '0.12'
 default['wkhtmltopdf-update']['version']     = '0.12.2.1'
 
 case node['platform_family']
@@ -35,4 +36,4 @@ else
   end
 end
 
-default['wkhtmltopdf-update']['mirror_url']  = "http://downloads.sourceforge.net/project/wkhtmltopdf/#{node['wkhtmltopdf-update']['version']}/#{node['wkhtmltopdf-update']['package']}"
+default['wkhtmltopdf-update']['mirror_url']  = "http://download.gna.org/wkhtmltopdf/#{node['wkhtmltopdf-update']['major_version']}/#{node['wkhtmltopdf-update']['version']}/#{node['wkhtmltopdf-update']['package']}"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jarvis@vortexrevolutions.com'
 license 'Apache 2.0'
 description 'Installs wkhtmltoimage and wkhtmltopdf'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.4.0'
+version '0.4.1'
 
 recipe 'wkhtmltopdf-update', 'Installs the latest wkhtmltoimage and wkhtmltopdf'
 recipe 'wkhtmltopdf-update::binary', 'Installs the latest wkhtmltoimage and wkhtmltopdf binaries'


### PR DESCRIPTION
With wkhtmltopdf.org moving from sourceforge to gna.org for its packages the attributes need to be updated to use the new URL.