### PR TITLE
New mirror URL and to install package issue

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-source "https://supermarket.chef.io"
+site :opscode
 
 metadata


### PR DESCRIPTION
These changes are the merge of two other users fixes made.
I did this repository to allow me to merge it and use them to be able to run this cookbook on my server.
I think it would be great to merge it with the base repository.

These fixes are to update the mirror URL to the new one, and a fix for an error on Ubuntu that throws that APT is not allowed to install packages with the source property with out indicate the proper Provider. 