### PR TITLE
Update Mirror URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3
+
+* Update the mirror URL to use downloads.wkhtmltopdf.org instead of gna.org
+
 ## 0.4.1
 
 * Update the mirror URL to use gna.org instead of sourceforge

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,4 +36,5 @@ else
   end
 end
 
-default['wkhtmltopdf-update']['mirror_url'] = "http://download.gna.org/wkhtmltopdf/#{node['wkhtmltopdf-update']['major_version']}/#{node['wkhtmltopdf-update']['version']}/#{node['wkhtmltopdf-update']['package']}"
+default['wkhtmltopdf-update']['mirror_url'] = "https://downloads.wkhtmltopdf.org/#{node['wkhtmltopdf-update']['major_version']}/#{node['wkhtmltopdf-update']['version']}/#{node['wkhtmltopdf-update']['package']}"
+

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jarvis@vortexrevolutions.com'
 license 'Apache 2.0'
 description 'Installs wkhtmltoimage and wkhtmltopdf'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.4.2'
+version '0.4.3'
 
 recipe 'wkhtmltopdf-update', 'Installs the latest wkhtmltoimage and wkhtmltopdf'
 recipe 'wkhtmltopdf-update::binary', 'Installs the latest wkhtmltoimage and wkhtmltopdf binaries'


### PR DESCRIPTION
gna.org has closed down. See: https://github.com/wkhtmltopdf/wkhtmltopdf/issues/3390